### PR TITLE
Misc cleanup to eldoc-box 

### DIFF
--- a/eldoc-box.el
+++ b/eldoc-box.el
@@ -1,11 +1,11 @@
 ;;; eldoc-box.el --- Display documentation in childframe      -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2017 Sebastien Chapuis
+;; Copyright (C) 2017-2018 Sebastien Chapuis, 2018 Yuan Fu
 
 ;; Version: 1.0
 
 ;; Author: Sebastien Chapuis <sebastien@chapu.is>
-;; Yuan Fu <casouri@gmail.com> made a lot of change to use it for ElDoc
+;; Maintainer: Yuan Fu <casouri@gmail.com>
 ;; URL: https://github.com/casouri/eldoc-box
 ;; Package-Requires: ((emacs "26.1"))
 
@@ -30,6 +30,7 @@
 
 ;;; Commentary:
 ;;
+;;  Made a lot of change to use it for ElDoc
 
 ;;; Code:
 ;;


### PR DESCRIPTION
Congratulations, it's very useful.  These is mostly cleanup and/or nitpicks.  Choose the ones you want.

The most important one is probably the switch to `run-with-timer` instead of `run-with-idle-timer`.  You don't have to keep a global list of minor-mode enabled buffers like this: the timer only runs once and is only re-launched when really needed.