### PR TITLE
Fix: Flicker when move out and into a eldoc-able symbol quickly

### DIFF
--- a/eldoc-box.el
+++ b/eldoc-box.el
@@ -229,21 +229,20 @@ Checkout `lsp-ui-doc--make-frame', `lsp-ui-doc--move-frame'."
 
 (defun eldoc-box--eldoc-message-function (str &rest args)
   "Front-end for eldoc. Display STR in childframe and ARGS works like `message'."
-  (if (stringp str)
-      (let ((doc (apply #'format str args)))
-        (unless (and eldoc-box-only-multi-line (eq (cl-count ?\n doc) 0))
-          (eldoc-box--display doc)
-          (setq eldoc-box--last-point (point))
-          ;; Why a timer? ElDoc is mainly used in minibuffer,
-          ;; where the text is constantly being flushed by other commands
-          ;; so ElDoc doesn't try very hard to cleanup
-          (when eldoc-box--cleanup-timer (cancel-timer eldoc-box--cleanup-timer))
-          ;; this function is also called by `eldoc-pre-command-refresh-echo-area'
-          ;; in `pre-command-hook', which means the timer is reset before every
-          ;; command if `eldoc-box-hover-mode' is on and `eldoc-last-message' is not nil.
-          (setq eldoc-box--cleanup-timer
-                (run-with-timer 1 nil #'eldoc-box--maybe-cleanup))))
-    (eldoc-box-quit-frame)
+  (when (stringp str)
+    (let ((doc (apply #'format str args)))
+      (unless (and eldoc-box-only-multi-line (eq (cl-count ?\n doc) 0))
+        (eldoc-box--display doc)
+        (setq eldoc-box--last-point (point))
+        ;; Why a timer? ElDoc is mainly used in minibuffer,
+        ;; where the text is constantly being flushed by other commands
+        ;; so ElDoc doesn't try very hard to cleanup
+        (when eldoc-box--cleanup-timer (cancel-timer eldoc-box--cleanup-timer))
+        ;; this function is also called by `eldoc-pre-command-refresh-echo-area'
+        ;; in `pre-command-hook', which means the timer is reset before every
+        ;; command if `eldoc-box-hover-mode' is on and `eldoc-last-message' is not nil.
+        (setq eldoc-box--cleanup-timer
+              (run-with-timer 1 nil #'eldoc-box--maybe-cleanup))))
     t))
 
 (provide 'eldoc-box)


### PR DESCRIPTION
- (eldox-box--eldoc-message-function): doesn't cleanup childframe
  when passed with nil anymore

I finally figured out why the flicker occurs:

1. when eldoc asks for doc string, elgot returns nil immediately
2. when you move out of a eldoc-cable symbol and move back in,
   the childframe isn't cleaned up. And eldoc receives nil from
   eglot, passes that to message function (eldoc-message)
   -> (eldoc-message-function), eldoc-box gets it and cleans up
   childframe. Then eglot receives doc string from server
   and calls (eldoc-message), childframe is then redisplayed.

Since eldoc-box cleans up after itself and doesn't rely on eldoc
to cleanup, a quick fix is simply to not clean up when eldoc-box
(eldoc-box--eldoc-message-function) recieves nil from eldoc
(eldoc-message).
