### PR TITLE
Fix child border in Emacs 28

### DIFF
--- a/eldoc-box.el
+++ b/eldoc-box.el
@@ -331,6 +331,10 @@ Checkout `lsp-ui-doc--make-frame', `lsp-ui-doc--move-frame'."
       (set-window-dedicated-p window t)
       (redirect-frame-focus frame (frame-parent frame))
       (set-face-attribute 'internal-border frame :inherit 'eldoc-box-border)
+      (when (facep 'child-frame-border)
+        (set-face-background 'child-frame-border
+                             (face-attribute 'eldoc-box-border :background)
+                             frame))
       ;; set size
       (eldoc-box--update-childframe-geometry frame window)
       (setq eldoc-box--frame frame)


### PR DESCRIPTION
This is similar to the fix recently added to `lsp-ui` (https://github.com/emacs-lsp/lsp-ui/pull/616).

Before:

<img width="946" alt="Screen Shot 2021-05-22 at 2 12 11 PM" src="https://user-images.githubusercontent.com/3202090/119236868-baea1400-bb07-11eb-8e8b-22f68076980c.png">

After:

<img width="968" alt="Screen Shot 2021-05-22 at 2 11 08 PM" src="https://user-images.githubusercontent.com/3202090/119236871-bde50480-bb07-11eb-8199-db87ea6d1abb.png">

(the patch doesn't affect Emacs 27.2, which never had the issue).