### PR TITLE
add customizable eldoc-box-offset

### DIFF
--- a/eldoc-box.el
+++ b/eldoc-box.el
@@ -115,6 +115,14 @@ Set it to a function with no argument
 if you want to dynamically change the maximum height."
   :type 'number)
 
+(defcustom eldoc-box-offset '(16 16 16)
+  "Sets left, right & top offset of the doc childframe.
+Its value should be a list: (left right top)"
+  :type '(list
+          (integer :tag "Left")
+          (integer :tag "Right")
+          (integer :tag "Top")))
+
 (defvar eldoc-box-position-function #'eldoc-box--default-upper-corner-position-function
   "Eldoc-box uses this function to set childframe's position.
 This should be a function that returns a (X . Y) cons cell.
@@ -207,13 +215,15 @@ Intended for internal use."
   "The default function to set childframe position.
 Used by `eldoc-box-position-function'.
 Position is calculated base on WIDTH and HEIGHT of childframe text window"
-  (cons (pcase (eldoc-box--window-side) ; x position + a little padding (16)
-          ;; display doc on right
-          ('left (- (frame-outer-width (selected-frame)) width 16))
-          ;; display doc on left
-          ('right 16))
-        ;; y position + a little padding (16)
-        16))
+  (pcase-let ((`(,offset-l ,offset-r ,offset-t) eldoc-box-offset))
+    (cons (pcase (eldoc-box--window-side) ; x position + offset
+            ;; display doc on right
+            ('left (- (frame-outer-width (selected-frame)) width offset-r))
+            ;; display doc on left
+            ('right offset-l))
+          ;; y position + v-offset
+          offset-t)
+    ))
 
 (defun eldoc-box--point-position-relative-to-native-frame (&optional point window)
   "Return (X . Y) as the coordinate of POINT in WINDOW.


### PR DESCRIPTION
I had this silly problem with Gnome 41 + Emacs 26 where the child box floats too far over when it's positioned to the right. Its especially bad on multi-line docs as words could get truncated by the frame edge. 

![Screenshot from 2022-02-12 00-01-24](https://user-images.githubusercontent.com/28788713/153702920-7a6609aa-2f49-497e-b280-0824253bcd82.png)

I wanted a way to adjust the offset so I could compensate for that problem, so I wrote it. I figured this might be a welcome feature upstream :)

Let me know if you have any questions.