### PR TITLE
Cleanup: quiet warnings

### DIFF
--- a/eldoc-box.el
+++ b/eldoc-box.el
@@ -9,7 +9,7 @@
 ;; Contributors:
 ;;   João Távora <joaotavora@gmail.com>
 ;; URL: https://github.com/casouri/eldoc-box
-;; Package-Requires: ((emacs "26.1"))
+;; Package-Requires: ((emacs "27.1"))
 
 ;;; License
 ;;
@@ -67,7 +67,7 @@ in that mode the childframe is cleared as soon as point moves."
   :type 'number)
 
 (defcustom eldoc-box-clear-with-C-g nil
-  "If set to non-nil, eldoc-box clears childframe when you hit \C-g."
+  "If set to non-nil, eldoc-box clears childframe on \\[keyboard-quit]."
   :type 'boolean)
 
 (defvar eldoc-box-frame-parameters
@@ -142,7 +142,7 @@ Run inside the new buffer.")
 Each function runs inside the new frame and receives the main frame as argument.")
 
 (defcustom eldoc-box-self-insert-command-list '(self-insert-command outshine-self-insert-command)
-  "Commands in this list are considered self-insert-command by eldoc-box.
+  "Commands in this list are considered `self-insert-command' by eldoc-box.
 See `eldoc-box-inhibit-display-when-moving'."
   :type '(repeat symbol))
 
@@ -205,8 +205,9 @@ STR has to be a proper documentation, not empty string, not nil, etc."
 
 
 (defun eldoc-box--window-side ()
-  "Return 'left if the selected window is on the left,
-'right if on the right. Return 'left if there is only one window."
+  "Return the side of the selected window.
+Symbol 'left if the selected window is on the left,'right if on the right.
+Return 'left if there is only one window."
   (let ((left-window(window-at 0 0)))
     (if (eq left-window (selected-window))
         'left
@@ -223,8 +224,7 @@ Position is calculated base on WIDTH and HEIGHT of childframe text window"
             ;; display doc on left
             ('right offset-l))
           ;; y position + v-offset
-          offset-t)
-    ))
+          offset-t)))
 
 (defun eldoc-box--point-position-relative-to-native-frame (&optional point window)
   "Return (X . Y) as the coordinate of POINT in WINDOW.
@@ -241,7 +241,7 @@ WINDOW nil means use selected window."
           (+ y (cadr edges)))))
 
 (defun eldoc-box--default-at-point-position-function-1 (width height)
-  "See `eldoc-box--default-at-point-position-function'."
+  "See `eldoc-box--default-at-point-position-function' for WIDTH & HEIGHT docs."
   (let* ((point-pos (eldoc-box--point-position-relative-to-native-frame))
          ;; calculate point coordinate relative to native frame
          ;; because childframe coordinate is relative to native frame
@@ -262,8 +262,9 @@ WINDOW nil means use selected window."
             (+ y em)))))
 
 (defun eldoc-box--default-at-point-position-function (width height)
-  "Set `eldoc-box-position-function' to this function to have childframe appear under point.
-Position is calculated base on WIDTH and HEIGHT of childframe text window."
+  "Set `eldoc-box-position-function' to this function.
+To have childframe appear under point.  Position is calculated
+base on WIDTH and HEIGHT of childframe text window."
   (let* ((pos (eldoc-box--default-at-point-position-function-1 width height))
          (x (car pos))
          (y (cdr pos)))
@@ -392,7 +393,8 @@ Checkout `lsp-ui-doc--make-frame', `lsp-ui-doc--move-frame'."
           (run-with-timer eldoc-box-cleanup-interval nil #'eldoc-box--maybe-cleanup))))
 
 (defun eldoc-box--eldoc-message-function (str &rest args)
-  "Front-end for eldoc. Display STR in childframe and ARGS works like `message'."
+  "Front-end for eldoc.
+Display STR in childframe and ARGS works like `message'."
   (when (and (stringp str) (not (equal str "")))
     (let* ((doc (string-trim-right (apply #'format str args)))
            (single-line-p (and eldoc-box-only-multi-line
@@ -425,7 +427,7 @@ The default position of childframe is upper corner."
 ;;;###autoload
 (define-minor-mode eldoc-box-hover-at-point-mode
   "A convenient minor mode to display doc at point.
-You can use C-g to hide the doc."
+You can use \[keyboard-quit] to hide the doc."
   :lighter " ELDOC-BOX"
   (if eldoc-box-hover-at-point-mode
       (progn (when eldoc-box-hover-mode


### PR DESCRIPTION
Quiet warnings from compiling, package-lint, checkdoc & byte-code compiling.

```
eldoc-box.el:264:2: Warning: docstring wider than 80 characters
227:4: warning: Closing parens should not be wrapped onto new lines.
eldoc-box.el:70: Keycode C-g embedded in doc string.  Use \\<mapvar> & \\[command] instead
eldoc-box.el:145: Lisp symbol ‘self-insert-command’ should appear in quotes
eldoc-box.el:208: First line is not a complete sentence
eldoc-box.el:209: There should be two spaces after a period
eldoc-box.el:244: Argument ‘width’ should appear (as WIDTH) in the doc string
eldoc-box.el:265: Some lines are over 80 columns wide
eldoc-box.el:395: There should be two spaces after a period
eldoc-box.el:428: Keycode C-g embedded in doc string.  Use \\<mapvar> & \\[command] instead
475:22: error: You should depend on (emacs "27.1") or the jsonrpc package if you need `jsonrpc-request'.
```