### PR TITLE
Correct eldoc-box-body face

### DIFF
--- a/eldoc-box.el
+++ b/eldoc-box.el
@@ -51,7 +51,7 @@
                             (((background light)) . (:background "black")))
   "The border color used in childframe.")
 
-(defface eldoc-box-body '((t . (:background nil)))
+(defface eldoc-box-body '((t . (:background unspecified)))
   "Body face used in documentation childframe.")
 
 (defcustom eldoc-box-only-multi-line nil


### PR DESCRIPTION
As of emacs 29 this generates a warning.

----

This resolves warning.

Warning: setting attribute ‘:background’ of face ‘eldoc-box-body’: nil value is invalid, use ‘unspecified’ instead.
