### PR TITLE
Fix eldoc-box-body rendering in Customize

### DIFF
--- a/eldoc-box.el
+++ b/eldoc-box.el
@@ -81,7 +81,7 @@
                             (((background light)) . (:background "black")))
   "The border color used in childframe.")
 
-(defface eldoc-box-body '((t . (:background unspecified)))
+(defface eldoc-box-body '((t . nil))
   "Body face used in documentation childframe.")
 
 (defcustom eldoc-box-only-multi-line nil


### PR DESCRIPTION
At least on my build (28.2), defining the face with `:background unspecified` makes Customize only show the raw lisp expression. Setting it to `'((t . nil))` makes it work.