### PR TITLE
fix warning in Emacs 29 when set fring background to nil

### DIFF
--- a/eldoc-box.el
+++ b/eldoc-box.el
@@ -436,7 +436,7 @@ Checkout `lsp-ui-doc--make-frame', `lsp-ui-doc--move-frame'."
       ;; (set-frame-parameter frame 'left-fringe (alist-get 'left-fringe eldoc-box-frame-parameters))
       ;; (set-frame-parameter frame 'right-fringe (alist-get 'right-fringe eldoc-box-frame-parameters))
 
-      (set-face-attribute 'fringe frame :background nil :inherit 'eldoc-box-body)
+      (set-face-attribute 'fringe frame :background 'unspecified :inherit 'eldoc-box-body)
       (set-window-dedicated-p window t)
       (redirect-frame-focus frame (frame-parent frame))
       (set-face-attribute 'internal-border frame :inherit 'eldoc-box-border)


### PR DESCRIPTION
Hi,

I'm using Emacs 29 and it constantly throws complains that `eldoc-box` should not set  `:background` of `fringe` to `nil`.

``` sh
Warning: setting attribute ‘:background’ of face ‘fringe’: nil value is invalid, use ‘unspecified’ instead. [3 times]
Warning: setting attribute ‘:background’ of face ‘fringe’: nil value is invalid, use ‘unspecified’ instead.
```

So, this PR changes the background to `unspecified` instead.

Can you consider merging this PR?

Thanks!