### PR TITLE
Add keymap for eldoc-box

### DIFF
--- a/README.org
+++ b/README.org
@@ -39,6 +39,7 @@ It is also available on [[https://melpa.org/#/eldoc-box][MELPA]].
 - =eldoc-box-fringe-use-same-bg= :: Whether to set fringe’s background color to as same as that of default. Default to t.
 - =eldoc-box-self-insert-command-list= :: By default =eldoc-box-hover-at-point-mode= only keeps childframe display while you are typing (ie, when =this-command= is =self-insert-command=). But if you bind something else to your keys, eldoc-box can’t recognize it and will hide childframe when you type. Add your command to this list so eldoc-box won’t hide childframe when this command is called.
 - =eldoc-box-lighter= :: Lighter displayed on the mode line.
+- =eldoc-box-use-extra-commands-map= :: Set this to non-nil, and =eldoc-box-extra-commands-map= will be activated when childframe is visible, deactivated when the frame is invisble.  =eldoc-box-extra-commands-map= makes ~scroll-other-window~, ~scroll-other-window-down~, ~beginning-of-buffer-other-window~ and ~end-of-buffer-other-window~ activated on the eldoc-box's childframe.  When eldoc-box's childframe is invisible, these commands will behave as they are.
 
 ** Use with eglot
 

--- a/eldoc-box.el
+++ b/eldoc-box.el
@@ -304,7 +304,6 @@ STR has to be a proper documentation, not empty string, not nil, etc."
       (run-hook-with-args 'eldoc-box-buffer-hook))
     (eldoc-box--get-frame doc-buffer)))
 
-
 (defun eldoc-box--window-side ()
   "Return the side of the selected window.
 Symbol ‘left’ if the selected window is on the left, ‘right’ if
@@ -373,6 +372,7 @@ base on WIDTH and HEIGHT of childframe text window."
          (y (cdr pos)))
     (cons (or (eldoc-box--at-point-x-by-company) x)
           y)))
+
 (defun eldoc-box--update-childframe-geometry (frame window)
   "Update the size and the position of childframe.
 FRAME is the childframe, WINDOW is the primary window."
@@ -408,8 +408,8 @@ FRAME is the childframe, WINDOW is the primary window."
     (setq eldoc-box--inhibit-childframe t)
     (eldoc-box-quit-frame)
     (run-with-idle-timer sec nil
-                    (lambda ()
-                      (setq eldoc-box--inhibit-childframe nil)))))
+                         (lambda ()
+                           (setq eldoc-box--inhibit-childframe nil)))))
 
 (defun eldoc-box--follow-cursor ()
   "Make childframe follow cursor in at-point mode."
@@ -592,7 +592,7 @@ display the docs in echo area depending on
 
 ;;;###autoload
 (define-minor-mode eldoc-box-hover-mode
-  "Displays hover documentations in a childframe.
+  "Display hover documentations in a childframe.
 The default position of childframe is upper corner."
   :lighter eldoc-box-lighter
   (if eldoc-box-hover-mode
@@ -604,7 +604,7 @@ The default position of childframe is upper corner."
 ;;;###autoload
 (define-minor-mode eldoc-box-hover-at-point-mode
   "A convenient minor mode to display doc at point.
-You can use \[keyboard-quit] to hide the doc."
+You can use \\[keyboard-quit] to hide the doc."
   :lighter eldoc-box-lighter
   (if eldoc-box-hover-at-point-mode
       (progn (when eldoc-box-hover-mode
@@ -633,7 +633,7 @@ instead."
   (interactive)
   (eldoc-box-help-at-point))
 
-;;;; Comany compatibility
+;;;; Company compatibility
 ;;
 
 ;; see also `eldoc-box--default-at-point-position-function'


### PR DESCRIPTION
On Windows, eldoc-box's childframe can not be selected by cursor, and I
can't scroll the childframe with mouse. So I write a keymap for it.