### PR TITLE
Prevent tab-bar from activating on the childframe

### DIFF
--- a/eldoc-box.el
+++ b/eldoc-box.el
@@ -146,7 +146,8 @@ This separator is used for the documentation shown in
     (drag-internal-border . t)
     (no-special-glyphs . t)
     (desktop-dont-save . t)
-    (tab-bar-lines . 0))
+    (tab-bar-lines . 0)
+    (tab-bar-lines-keep-state . 1))
   "Frame parameters used to create the frame.")
 
 (defcustom eldoc-box-max-pixel-width 800


### PR DESCRIPTION
Fix issue #88.

When activating `tab-bar`, it calls `(tab-bar--update-tab-bar-lines t)`, which will activating `tab-bar` on all frames, including childframes.

By setting `tab-bar-lines-keep-state` to `1` on childframes, `tab-bar--update-tab-bar-lines` will ignore theses childframes.