### PR TITLE
Handle pos-visible-in-window-p being nil

### DIFF
--- a/eldoc-box.el
+++ b/eldoc-box.el
@@ -371,6 +371,9 @@ Position is calculated base on WIDTH and HEIGHT of childframe text window"
 The coordinate is relative to the native frame.
 
 WINDOW nil means use selected window."
+  (unless point
+    ;; Handle edge case. See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=69259.
+    (setq point (window-point window)))
   (let* ((pos (pos-visible-in-window-p point window t))
          (x (car pos))
          (en (frame-char-width))


### PR DESCRIPTION
I'm using EXWM with `persp-mode` and have noticed `eldoc-box` emitting an error when `pos-visible-in-window-p` is nil. This commit works around that error by just no-oping if `pos-visible-in-window-p` is nil.