### PR TITLE
fontify-html: don't show p-tags

### DIFF
--- a/eldoc-box.el
+++ b/eldoc-box.el
@@ -795,6 +795,7 @@ height."
       (put-text-property (match-beginning 3) (match-end 3)
                          'invisible t))
     ;; don't show these tags
+    (goto-char (point-min))
     (while (re-search-forward
             (rx (group "<p>")
                 (group (*? anychar))

--- a/eldoc-box.el
+++ b/eldoc-box.el
@@ -794,6 +794,16 @@ height."
                          'invisible t)
       (put-text-property (match-beginning 3) (match-end 3)
                          'invisible t))
+    ;; don't show these tags
+    (while (re-search-forward
+            (rx (group "<p>")
+                (group (*? anychar))
+                (group "</p>"))
+            nil t)
+      (put-text-property (match-beginning 1) (match-end 1)
+                         'invisible t)
+      (put-text-property (match-beginning 3) (match-end 3)
+                         'invisible t)))
     ;; Special entities.
     (goto-char (point-min))
     (while (re-search-forward (rx (or "&lt;" "&gt;" "&nbsp;")) nil t)


### PR DESCRIPTION
Some documentation has paragraph-tags in the documentation - this patch hides these tags.