### PR TITLE
Fix eldoc-box--help-at-point-async-update: mapcar -> mapconcat

### DIFF
--- a/eldoc-box.el
+++ b/eldoc-box.el
@@ -297,7 +297,7 @@ For DOCS, see ‘eldoc-display-functions’."
     (let ((eldoc-box-position-function
            eldoc-box-at-point-position-function))
       (eldoc-box--display
-       (concat (mapcar #'car docs)
+       (concat (mapconcat #'car docs)
                (concat "\n"
                        (or eldoc-doc-buffer-separator "---")
                        "\n"))))))


### PR DESCRIPTION
I had problems when updating the eldoc-box frame until I changed `mapcar` to `mapconcat` in `eldoc-box--help-at-point-async-update`.

`concat` does not accept a list of strings as its arguments. Is this an unintentional mistake?