### PR TITLE
Clear window margins after child window has been created

### DIFF
--- a/eldoc-box.el
+++ b/eldoc-box.el
@@ -349,7 +349,6 @@ STR has to be a proper documentation, not empty string, not nil, etc."
       ;; `eldoc-box--cleanup-timer' will clear the childframe
       (buffer-face-set 'eldoc-box-body)
       (setq eldoc-box-hover-mode t)
-      (set-window-margins nil nil nil)
       (erase-buffer)
       (insert str)
       (goto-char (point-min))
@@ -535,6 +534,7 @@ Checkout `lsp-ui-doc--make-frame', `lsp-ui-doc--move-frame'."
                              (face-attribute 'eldoc-box-border :background nil t)
                              frame))
       (eldoc-box--update-childframe-geometry frame window)
+      (set-window-margins window nil nil)
       (setq eldoc-box--frame frame)
       (with-selected-frame frame
         (run-hook-with-args 'eldoc-box-frame-hook main-frame))


### PR DESCRIPTION
Fixes #107.

When window margins are cleared in the current location, this clears the parent's window margins as it is the selected window at that point in time and the child window might not even exist yet.

* eldoc-box.el (eldoc-box--display): Remove set-window-margins.
(eldoc-box--get-frame): Add set-window-margins.