### PR TITLE
Fix `buffer-local-value` call in eldoc-box-prettify-ts-errors

### DIFF
--- a/eldoc-box.el
+++ b/eldoc-box.el
@@ -924,7 +924,7 @@ the compiler truncates the types and formatting wouldn’t work."
         fontified-type
         multi-line)
     (with-current-buffer workbuf
-      (funcall (buffer-local-value orig-buffer 'major-mode)))
+      (funcall (buffer-local-value 'major-mode orig-buffer)))
     ;; 1. Prettify types.
     (while (re-search-forward
             ;; Typescript uses doble quotes for literal unions like


### PR DESCRIPTION
This PR fixes the order of the arguments for the call to `buffer-local-value` in  eldoc-box-prettify-ts-errors.

The signature of `buffer-local-value` is `(buffer-local-value VARIABLE BUFFER)`, but the arguments were reversed here, causing a type error when calling eldoc-box-prettify-ts-errors.