### PR TITLE
Copy value of eldoc-box-buffer-setup-hook for orig-buffer

### DIFF
--- a/eldoc-box.el
+++ b/eldoc-box.el
@@ -388,6 +388,10 @@ For DOCS, see ‘eldoc-display-functions’."
   (buffer-face-set 'eldoc-box-body)
   (setq eldoc-box-hover-mode t)
   (visual-line-mode)
+  ;; Use buffer-local binding in the original buffer
+  ;; for the setup hook to allow original mode-specific setup.
+  (setq-local eldoc-box-buffer-setup-hook
+              (buffer-local-value 'eldoc-box-buffer-setup-hook orig-buffer))
   (run-hook-with-args 'eldoc-box-buffer-setup-hook orig-buffer)
   (run-hook-with-args 'eldoc-box-buffer-hook))
 


### PR DESCRIPTION
This PR updates the `eldoc-box--display` function to store the value of `eldoc-box-buffer-setup-hook` from the original buffer and sets it to that value locally in the eldoc-box buffer. 

This is needed because otherwise, `eldoc-box-buffer-setup-hook` cannot be set locally to a buffer, since its value is referred to while `eldoc-box--buffer` is the current buffer. This means that adding a hook to configure mode specific setup e.g. as directed in the [README for typescript](https://github.com/casouri/eldoc-box/blob/1a2f604ef290bd50f46ad7b324b058c4650d272f/README.org#prettify-typescript-error-message) does not currently work, since any buffer-local values would need to be set in the doc buffer, not the original typescript buffer.

With the changes here, one can configure mode specific setup like the readme advises:
```emacs-lisp
(add-hook 'typescript-ts-base-mode-hook
          (lambda ()
            (add-hook 'eldoc-box-buffer-setup-hook #'eldoc-box-prettify-ts-errors 0 t))))

```