### PR TITLE
Improve the display of child frame for hover at point

### DIFF
--- a/eldoc-box.el
+++ b/eldoc-box.el
@@ -470,8 +470,8 @@ WINDOW nil means use selected window."
          (em (frame-char-height)))
     (cons (if (< (- (frame-inner-width) width) x)
               ;; space on the right of the pos is not enough
-              ;; put to left
-              (max 0 (- x width))
+              ;; make sure the right edge of the child frame still in the emacs window.
+              (max 0 (- (frame-inner-width) width))
             ;; normal, just return x
             x)
           (if (< (- (frame-inner-height) height) y)


### PR DESCRIPTION
When there is not enough space on the right to display the child frame, move the child frame left so the right edge of the child frame still in the emacs window, but keep the child frame at right side of the window as much as possible, so it hide the code as little as possible. Code is usually concentrated on the left side of the editor.