### PR TITLE
Fix custom types

### DIFF
--- a/eldoc-box.el
+++ b/eldoc-box.el
@@ -166,14 +166,14 @@ This separator is used for the documentation shown in
 Consider your machine's screen's resolution when setting this variable.
 Set it to a function with no argument
 if you want to dynamically change the maximum width."
-  :type 'number)
+  :type '(choice number function))
 
 (defcustom eldoc-box-max-pixel-height 700
   "Maximum height of doc childframe in pixel.
 Consider your machine's screen's resolution when setting this variable.
 Set it to a function with no argument
 if you want to dynamically change the maximum height."
-  :type 'number)
+  :type '(choice number function))
 
 (defcustom eldoc-box-offset '(16 16 16)
   "Sets left, right & top offset of the doc childframe.


### PR DESCRIPTION
* eldoc-box.el (eldoc-box-max-pixel-height, eldoc-box-max-pixel-width): Include
`function` as a choice in custom types.